### PR TITLE
修复低版本 Node.JS 复制文件出错

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,7 +23,7 @@ function convertToPng(img) {
     }
     if (ext !== '.png') {
       // rust里的image.open依赖文件后缀，所以如果是png格式但是后缀不是png，需要复制一份
-      fs.cpSync(img, tmpPath);
+      fs.copyFileSync(img, tmpPath);
       return tmpPath;
     }
     return img;


### PR DESCRIPTION
fs.cpSync 是后面加的，低版本上用不了。

<img width="904" alt="image" src="https://user-images.githubusercontent.com/24544721/223719079-2e456cc1-dbda-448d-83d8-270b0e038f6b.png">

Use previous method for backward compatibility with Node.js.